### PR TITLE
new claranet php image

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,16 +1,18 @@
 #!/bin/bash
 
 PUSH_IMAGE=${PUSH_IMAGE:-1}
-BASE_VERSION=1.1.2
+BASE_VERSION=1.1.3
 PHP_VERSIONS=(7.3.27)
+CLARA_PHP_TAG=1.1.51
 IMAGE_NAME=claranet/magento-base
 
 build_phpbase() {
   WORKDIR=$(mktemp -d)
+  
   cd ${WORKDIR}
   git clone https://github.com/claranet/php.git ./
-  git fetch
-  git checkout --track origin/feature/debian-buster
+  git fetch --all --tags
+  git checkout ${CLARA_PHP_TAG}
   PHP_VERSION=${PHP_VERSION} FROM_IMAGE=php:${PHP_VERSION}-fpm-buster ./bin/image.sh build
   cd $OLDPWD
   rm -rf ${WORKDIR}
@@ -20,7 +22,7 @@ build_magentobase() {
   echo "BUILD IMAGE FOR PHP ${PHP_VERSION}"
   BUILD_TAG=$1
   docker build -t $1 \
-               --build-arg FROM_IMAGE=local/claranet/php:1.1.48-php${PHP_VERSION} \
+               --build-arg FROM_IMAGE=local/claranet/php:${CLARA_PHP_TAG}-php${PHP_VERSION} \
                --build-arg PHP_VERSION \
                .
   

--- a/docker/shared_steps/magento_bootstrap.sh
+++ b/docker/shared_steps/magento_bootstrap.sh
@@ -2,7 +2,11 @@
 
 echo "START Magento Bootstrap"
 
+DEBUG=${MAGENTO_DOCKER_DEBUG:-false}
+
+if [ "$DEBUG" = true ] ; then
 set -x
+fi
 
 if [ -d /var/run/secrets/kubernetes.io ]; then
 


### PR DESCRIPTION
* Build new version with new Claranet PHP Image 1.0.51
* Remove `set -x` out of startup script because it is more debug messages and it generates more logs in Google Logging. Now you are able to enable it with environment variable `MAGENTO_DOCKER_DEBUG=true`